### PR TITLE
Issues on Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,11 @@ Remove iSCSI initiator software (`iscsdi` or `open-iscsi`).
 
 OS families
 ============
-Works on FreeBSD, RedHat, Debian, Arch, and Suse os families. The ``iscis.target`` state for Linux (``LIO target``) requires the ``target_core_mod`` kernel module, which some vagrant, and most container images, lack.  Archlinux needs AUR packages - you could use the ``users-formula`` to create required ``iscsimake`` (gid 0) user defined in ``osfamilymap.yaml`` for "Arch" - before executing the ``iscsi-formula``.
+Works on FreeBSD, RedHat, Debian, Arch, and Suse os families. The ``iscis.target`` state for Linux (``LIO target``) requires the ``target_core_mod`` kernel module, which some vagrant, and all container images, lack.  
 
-Arch(linux) additional Pillar-data::
+Archlinux
+---------
+AUR iscsi packages are supported. Run `users` state (users-formula) to create required ``iscsimake`` user (gid 0) on "Archlinux" before "iscsi-formula" states run. See example pillar data::
 
         iscsi:
         {% if grains.os == 'Arch' %}

--- a/iscsi/initiator/install.sls
+++ b/iscsi/initiator/install.sls
@@ -112,7 +112,7 @@ iscsi_initiator_service:
       - file: iscsi_initiator_service_config
         {% endif %}
     - name: {{ data.man5.svcname }}
-{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule %}
-    - unless: {{ "%s %s".format(iscsi.kernel.modquery, data.man5.kmodule) }}
-{% endif %}
+  {% if data.man5.kmodule %}
+    - unless: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
+  {% endif %}
 

--- a/iscsi/initiator/remove.sls
+++ b/iscsi/initiator/remove.sls
@@ -2,24 +2,27 @@
 # vim: ft=sls
 {% from "iscsi/map.jinja" import iscsi with context %}
 
+  {%- set provider = iscsi.client.provider -%}
+  {%- set data = iscsi.initiator[provider|string] -%}
+
 iscsi_initiator_service_dead:
   file.line:
-    - name: {{ man5.svcloadfile }}
-    - content: {{ man5.svcloadtext }}
+    - name: {{ data.man5.svcloadfile }}
+    - content: {{ data.man5.svcloadtext }}
     - backup: True
     - mode: delete
   service.dead:
     - enable: False
-{% if iscsi.kernel.mess_with_kernel and man5.kmodule %}
-    - onlyif: {{ "%s %s".format(iscsi.kernel.modquery, man5.kmodule) }}
-{%- endif -%}
+  {% if data.man5.kmodule %}
+    - onlyif: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
+  {%- endif -%}
 
 {%- set kmodule = iscsi.client['provider']['man5']['kmodule'] -%}
-{% if iscsi.kernel.mess_with_kernel and man5.kmodule and man5.kloadtext %}
-iscsi_initiator_kernel_module_{{ man5.kmodule }}_removed:
+{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
+iscsi_initiator_kernel_module_{{ data.man5.kmodule }}_removed:
   file.line:
     - name: {{ iscsi.kernel.modloadfile }}
-    - content: {{ man5.kloadtext }}
+    - content: {{ data.man5.kloadtext }}
     - backup: True
     - mode: delete
   cmd.run:

--- a/iscsi/target/defaults.yaml
+++ b/iscsi/target/defaults.yaml
@@ -107,8 +107,8 @@ iscsi:
         manpage:
         vendor: Kernel.org
         svcname: target
-        kmodule: target_core
-        modloadtext: target_core
+        kmodule: target_core_mod
+        modloadtext: target_core_mod
         svcloadfile:
         svcloadtext:
         config: /etc/target/saveconfig.json

--- a/iscsi/target/install.sls
+++ b/iscsi/target/install.sls
@@ -118,7 +118,7 @@ iscsi_target_service_running:
       - file: iscsi_target_service_config
         {% endif %}
     - name: {{ data.man5.svcname }}
-{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule %}
-    - unless: {{ "%s %s".format(iscsi.kernel.modquery, data.man5.kmodule) }}
+{% if data.man5.kmodule %}
+    - unless: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
 {% endif %}
 

--- a/iscsi/target/remove.sls
+++ b/iscsi/target/remove.sls
@@ -2,24 +2,28 @@
 # vim: ft=sls
 {% from "iscsi/map.jinja" import iscsi with context %}
 
+  {%- set provider = iscsi.server.provider -%}
+  {%- set data = iscsi.target[provider|string] -%}
+
 iscsi_target_service_dead:
   file.line:
-    - name: {{ man5.svcloadfile }}
-    - content: {{ man5.svcloadtext }}
+    - name: {{ data.man5.svcloadfile }}
+    - content: {{ data.man5.svcloadtext }}
     - backup: True
     - mode: delete
   service.dead:
     - enable: False
-{% if iscsi.kernel.mess_with_kernel and man5.kmodule %}
-    - onlyif: {{ "%s %s".format(iscsi.kernel.modquery, man5.kmodule) }}
-{% endif %}
+  {% if data.man5.kmodule %}
+    - onlyif: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
+  {% endif %}
 
 {% set kmodule = iscsi.server['provider']['man5']['kmodule'] %}
-{% if iscsi.kernel.mess_with_kernel and man5.kmodule and man5.kloadtext %}
-iscsi_target_kernel_module_{{ man5.kmodule }}_removed:
+
+{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
+iscsi_target_kernel_module_{{ data.man5.kmodule }}_removed:
   file.line:
     - name: {{ iscsi.kernel.modloadfile }}
-    - content: {{ man5.kloadtext }}
+    - content: {{ data.man5.kloadtext }}
     - backup: True
     - mode: delete
   cmd.run:


### PR DESCRIPTION
This PR should fix four issues which I observed on Ubuntu.
-  `"%s %s".format` jinja causes [SLS Rendering error](https://github.com/saltstack/salt/issues/34648). The format() is unnecessary. fix/removed.
- The `provider` and `data` jinja variables are missing in `remove.sls` states but are required. fix.
- `target_core` is a kernel module but `service.running/dead` are not detecting this.  To fix, I updated state unless conditionals to ensure kernel module check works.
- Also the correct kernel module name is `target_core_mod` not `target_core`.