### PR TITLE
Reworked jinja on Centos

### DIFF
--- a/iscsi/initiator/install.sls
+++ b/iscsi/initiator/install.sls
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{% from "iscsi/map.jinja" import iscsi with context %}
+{%- from "iscsi/map.jinja" import iscsi with context %}
 
-  {%- set provider = iscsi.client.provider -%}
-  {%- set data = iscsi.initiator[provider|string] -%}
+  {%- set provider = iscsi.client.provider %}
+  {%- set data = iscsi.initiator[provider|string] %}
 
-  {% for pkg in iscsi.client.pkgs.unwanted %}
-    {% if pkg %}
+  {%- if iscsi.client.pkgs.unwanted %}
+    {%- for pkg in iscsi.client.pkgs.unwanted %}
 iscsi_initiator_unwanted_pkgs_{{ pkg }}:
   pkg.purged:
     - name: {{ pkg }}
     - require_in:
       - file: iscsi_initiator_service_config
-    {% endif %}
-  {% endfor %}
+    {% endfor %}
+  {%- endif %}
 
-  {% for pkg in iscsi.client.pkgs.wanted %}
-    {% if pkg %}
+  {%- if iscsi.client.pkgs.wanted %}
+    {%- for pkg in iscsi.client.pkgs.wanted %}
 iscsi_initiator_wanted_pkgs_{{ pkg }}:
   pkg.installed:
     - name: {{ pkg }}
@@ -24,33 +24,35 @@ iscsi_initiator_wanted_pkgs_{{ pkg }}:
     - reload: True
     - require_in:
       - file: iscsi_initiator_service_config
-    {% endif %}
-  {% endfor %}
+    {% endfor %}
+  {%- endif %}
 
-{% if iscsi.client.make.wanted and salt['cmd.run']("id iscsi.user", output_loglevel='quiet') %}
-  {% for pkg in iscsi.client.make.wanted %}
-    {% if pkg %}
+{%-if iscsi.client.make.wanted and salt['cmd.run']("id iscsi.user", output_loglevel='quiet')%}
+  {%- for pkg in [iscsi.client.make.wanted,] %}
 iscsi_initiator_make_pkg_{{ pkg }}:
   file.directory:
     - name: /home/{{ iscsi.user }}
     - makedirs: True
     - user: {{ iscsi.user }}
     - dir_mode: '0755'
-      {% if iscsi.client.make.gitrepo %}
+      {%- if iscsi.client.make.gitrepo %}
   git.latest:
     - name: {{ iscsi.client.make.gitrepo }}/{{ pkg }}.git
     - target: /home/{{ iscsi.user }}/{{ pkg }}
     - user: {{ iscsi.user }}
+    - force_clone: True
+    - force_fetch: True
+    - force_reset: True
+    - force_checkout: True
     - require:
       - file: iscsi_initiator_make_pkg_{{ pkg }}
-      {% endif %}
+      {%- endif %}
   cmd.run:
     - cwd: /home/{{ iscsi.user }}/{{ pkg }}
     - name: {{ iscsi.client.make.cmd }}
     - runas: {{ iscsi.user }}
-    {% endif %}
   {% endfor %}
-{% endif %}
+{%- endif %}
 
 iscsi_initiator_service_config:
   file.managed:
@@ -67,18 +69,18 @@ iscsi_initiator_service_config:
         provider: {{ provider }}
         json: {{ data['man5']['format']['json'] }}
 
-{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
+  {%- if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
 iscsi_initiator_kernel_module:
   file.line:
     - name: {{ iscsi.kernel.modloadfile }}
     - content: {{ data.man5.kloadtext }}
     - backup: True
-        {% if not iscsi.client.enabled %}
+        {%- if not iscsi.client.enabled %}
     - mode: delete
   cmd.run:
     - name: {{ iscsi.initiator.kernel.modunload }}
     - onlyif: {{ iscsi.initiator.kernel.modquery }}
-        {% else %}
+        {%- else %}
     - mode: ensure
     - after: autoboot_delay.*$
   cmd.run:
@@ -86,10 +88,10 @@ iscsi_initiator_kernel_module:
     - unless: {{ iscsi.initiator.kernel.modquery }}
     - require:
       - file: iscsi_initiator_kernel_module
-        {% endif %}
+        {%- endif %}
     - require_in:
       - service: iscsi_initiator_service
-{% endif %}
+  {%- endif %}
 
 iscsi_initiator_service:
   file.line:
@@ -97,11 +99,11 @@ iscsi_initiator_service:
     - name: {{ data.man5.svcloadfile }}
     - content: {{ data.man5.svcloadtext }}
     - backup: True
-        {% if not iscsi.client.enabled %}
+        {%- if not iscsi.client.enabled %}
     - mode: delete
   service.disabled:
     - enable: False
-        {% else %}
+        {%- else %}
     - mode: ensure
     - after: ^salt.*$
   service.running:
@@ -110,9 +112,9 @@ iscsi_initiator_service:
       - file: iscsi_initiator_service_config
     - watch:
       - file: iscsi_initiator_service_config
-        {% endif %}
+        {%- endif %}
     - name: {{ data.man5.svcname }}
-  {% if data.man5.kmodule %}
+        {%- if data.man5.kmodule %}
     - unless: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
-  {% endif %}
+        {%- endif %}
 

--- a/iscsi/initiator/remove.sls
+++ b/iscsi/initiator/remove.sls
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{% from "iscsi/map.jinja" import iscsi with context %}
+{%- from "iscsi/map.jinja" import iscsi with context %}
 
-  {%- set provider = iscsi.client.provider -%}
-  {%- set data = iscsi.initiator[provider|string] -%}
+  {%- set provider = iscsi.client.provider %}
+  {%- set data = iscsi.initiator[provider|string] %}
 
 iscsi_initiator_service_dead:
   file.line:
@@ -13,12 +13,12 @@ iscsi_initiator_service_dead:
     - mode: delete
   service.dead:
     - enable: False
-  {% if data.man5.kmodule %}
+  {%- if data.man5.kmodule %}
     - onlyif: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
-  {%- endif -%}
+  {%- endif %}
 
-{%- set kmodule = iscsi.client['provider']['man5']['kmodule'] -%}
-{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
+  {%- set kmodule = iscsi.client['provider']['man5']['kmodule'] %}
+  {%- if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
 iscsi_initiator_kernel_module_{{ data.man5.kmodule }}_removed:
   file.line:
     - name: {{ iscsi.kernel.modloadfile }}
@@ -32,16 +32,14 @@ iscsi_initiator_kernel_module_{{ data.man5.kmodule }}_removed:
       - iscsi_initiator_service_dead
     - require_in:
       - iscsi_initiator_service_config_removed
-{% endif %}
+  {%- endif %}
 
-  {% for pkg in [iscsi.client.pkgs.unwanted, iscsi.client.pkgs.unwanted] %}
-    {% if pkg %}
+  {%- for pkg in [iscsi.client.pkgs.unwanted, iscsi.client.pkgs.unwanted,] %}
 iscsi_initiator_wanted_pkgs_{{ pkg }}_removed:
   pkg.purged:
     - name: {{ pkg }}
     - require_in:
       - file: iscsi_initiator_service_config_removed
-    {% endif %}
   {% endfor %}
 
 iscsi_initiator_service_config_removed:

--- a/iscsi/isns/remove.sls
+++ b/iscsi/isns/remove.sls
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-
-{% from "iscsi/map.jinja" import iscsi with context %}
+{%- from "iscsi/map.jinja" import iscsi with context %}
 
 iscsi_isns_service_name_stop:
   service.dead:
@@ -22,7 +21,7 @@ iscsi_isns_service_config_removed:
       - service: iscsi_isns_service_name_stop
       - file: iscsi_isns_service_config_backup
 
-  {% for pkg in [iscsi.isns.pkgs.wanted, iscsi.isns.pkgs.unwanted,] %}
+  {%- for pkg in [iscsi.isns.pkgs.wanted, iscsi.isns.pkgs.unwanted] %}
 iscsi_isns_remove_{{ pkg }}_pkg:
   pkg.purged:
     - pkg: {{ pkg }}

--- a/iscsi/osfamilymap.yaml
+++ b/iscsi/osfamilymap.yaml
@@ -104,13 +104,13 @@ RedHat:
   server:
     pkgs:
       wanted:
-        # scsi-target-utils
-        # fcoe-target-utils
         - libvirt-daemon-driver-storage-iscsi
         - netbsd-iscsi
         - udisks2-iscsi
         - yum-plugin-versionlock
         - targetcli
+        # scsi-target-utils
+        # fcoe-target-utils
 
 Suse:
   isns:

--- a/iscsi/target/install.sls
+++ b/iscsi/target/install.sls
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{% from "iscsi/map.jinja" import iscsi with context %}
+{%- from "iscsi/map.jinja" import iscsi with context %}
 
-  {%- set provider = iscsi.server.provider -%}
-  {%- set data = iscsi.target[provider|string] -%}
+  {%- set provider = iscsi.server.provider %}
+  {%- set data = iscsi.target[provider|string] %}
 
-  {% for pkg in iscsi.server.pkgs.unwanted %}
-    {% if pkg %}
+  {%- if iscsi.server.pkgs.unwanted %}
+    {%- for pkg in iscsi.server.pkgs.unwanted %}
 iscsi_target_unwanted_pkgs_{{ pkg }}:
   pkg.purged:
     - name: {{ pkg }}
     - require_in:
       - file: iscsi_target_service_config
-    {% endif %}
-  {% endfor %}
+    {% endfor %}
+  {%- endif %}
 
-  {% for pkg in iscsi.server.pkgs.wanted %}
-    {% if pkg %}
+  {%- if iscsi.server.pkgs.wanted %}
+    {%- for pkg in iscsi.server.pkgs.wanted %}
 iscsi_target_wanted_pkgs_{{ pkg }}:
   pkg.installed:
     - name: {{ pkg }}
@@ -24,33 +24,35 @@ iscsi_target_wanted_pkgs_{{ pkg }}:
     - reload: True
     - require_in:
       - file: iscsi_target_service_config
-    {% endif %}
-  {% endfor %}
+    {% endfor %}
+  {%- endif %}
 
-{% if iscsi.server.make.wanted and salt['cmd.run']("id iscsi.user", output_loglevel='quiet') %}
-  {% for pkg in iscsi.server.make.wanted %}
-    {% if pkg %}
+{%-if iscsi.server.make.wanted and salt['cmd.run']("id iscsi.user", output_loglevel='quiet')%}
+  {%- for pkg in iscsi.server.make.wanted %}
 iscsi_target_make_pkg_{{ pkg }}:
   file.directory:
     - name: /home/{{ iscsi.user }}
     - makedirs: True
     - user: {{ iscsi.user }}
     - dir_mode: '0755'
-      {% if iscsi.server.make.gitrepo %}
+      {%- if iscsi.server.make.gitrepo %}
   git.latest:
     - name: {{ iscsi.server.make.gitrepo }}/{{ pkg }}.git
     - target: /home/{{ iscsi.user }}/{{ pkg }}
     - user: {{ iscsi.user }}
+    - force_clone: True
+    - force_fetch: True
+    - force_reset: True
+    - force_checkout: True
     - require:
       - file: iscsi_target_make_pkg_{{ pkg }}
-      {% endif %}
+      {%- endif %}
   cmd.run:
     - cwd: /home/{{ iscsi.user }}/{{ pkg }}
     - name: {{ iscsi.server.make.cmd }}
     - runas: {{ iscsi.user }}
-    {% endif %}
   {% endfor %}
-{% endif %}
+{%- endif %}
 
 iscsi_target_service_config:
   file.managed:
@@ -67,18 +69,18 @@ iscsi_target_service_config:
         provider: {{ provider }}
         json: {{ data['man5']['format']['json'] }}
 
-{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
+  {%- if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
 iscsi_target_kernel_module:
   file.line:
     - name: {{ iscsi.kernel.modloadfile }}
     - content: {{ data.man5.kloadtext }}
     - backup: True
-        {% if not data.enabled %}
+        {%- if not data.enabled %}
     - mode: delete
   cmd.run:
     - name: {{ data.kernel.modunload }}
     - onlyif: {{ data.kernel.modquery }}
-        {% else %}
+        {%- else %}
     - mode: ensure
     - after: 'autoboot_delay.*'
   cmd.run:
@@ -86,39 +88,39 @@ iscsi_target_kernel_module:
     - unless: {{ data.kernel.modquery }}
     - require:
       - file: iscsi_target_kernel_module
-        {% endif %}
+        {%- endif %}
     - require_in:
       - service: iscsi_target_service_running
-{% endif %}
+  {%- endif %}
 
-  {% if grains.os == 'FreeBSD' %}
+  {%- if grains.os == 'FreeBSD' %}
 iscsi_target_service_freebsd_support:
   file.line:
     - name: {{ data.man5.svcloadfile }}
     - content: 'ctld_env="-u"'
     - backup: True
-        {% if not iscsi.server.enabled %}
+        {%- if not iscsi.server.enabled %}
     - mode: delete
-        {% else %}
+        {%- else %}
     - mode: ensure
     - after: 'sshd_enable.*'
-        {% endif %}
- {% endif %}
+        {%- endif %}
+  {%- endif %}
 
 iscsi_target_service_running:
-        {% if not iscsi.server.enabled %}
+        {%- if not iscsi.server.enabled %}
   service.disabled:
     - enable: False
-        {% else %}
+        {%- else %}
   service.running:
     - enable: True
     - require:
       - file: iscsi_target_service_config
     - watch:
       - file: iscsi_target_service_config
-        {% endif %}
+        {%- endif %}
     - name: {{ data.man5.svcname }}
-{% if data.man5.kmodule %}
+  {%- if data.man5.kmodule %}
     - unless: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
-{% endif %}
+  {%- endif %}
 

--- a/iscsi/target/remove.sls
+++ b/iscsi/target/remove.sls
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{% from "iscsi/map.jinja" import iscsi with context %}
+{%- from "iscsi/map.jinja" import iscsi with context %}
 
-  {%- set provider = iscsi.server.provider -%}
-  {%- set data = iscsi.target[provider|string] -%}
+  {%- set provider = iscsi.server.provider %}
+  {%- set data = iscsi.target[provider|string] %}
 
 iscsi_target_service_dead:
   file.line:
@@ -13,13 +13,13 @@ iscsi_target_service_dead:
     - mode: delete
   service.dead:
     - enable: False
-  {% if data.man5.kmodule %}
+  {%- if data.man5.kmodule %}
     - onlyif: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
-  {% endif %}
+  {%- endif %}
 
-{% set kmodule = iscsi.server['provider']['man5']['kmodule'] %}
 
-{% if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
+  {%- set kmodule = iscsi.server['provider']['man5']['kmodule'] %}
+  {%- if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
 iscsi_target_kernel_module_{{ data.man5.kmodule }}_removed:
   file.line:
     - name: {{ iscsi.kernel.modloadfile }}
@@ -33,16 +33,14 @@ iscsi_target_kernel_module_{{ data.man5.kmodule }}_removed:
       - iscsi_target_service_dead
     - require_in:
       - iscsi_target_service_config_removed
-{% endif %}
+  {%- endif %}
 
-  {% for pkg in [iscsi.server.pkgs.unwanted, iscsi.server.pkgs.unwanted] %}
-    {% if pkg %}
+  {%- for pkg in [iscsi.server.pkgs.unwanted, iscsi.server.pkgs.unwanted] %}
 iscsi_target_wanted_pkgs_{{ pkg }}_removed:
   pkg.purged:
     - name: {{ pkg }}
     - require_in:
       - file: iscsi_target_service_config_removed
-    {% endif %}
   {% endfor %}
 
 iscsi_target_service_config_removed:


### PR DESCRIPTION
This PR improves the rendering of JINJA formatting for formula.

Note: I was troubleshooting these warnings/noise on CentOS but have not found fix yet ...
```
[ERROR   ] Invalid input for repack_dictlist, data passed is not a list ({u'libiscsi': None})
[ERROR   ] Invalid input for repack_dictlist, data passed is not a list ({u'libiscsi-utils': None})
```