### PR TITLE
fix #10 on Ubuntu

### DIFF
--- a/iscsi/osfamilymap.yaml
+++ b/iscsi/osfamilymap.yaml
@@ -30,6 +30,7 @@ Debian:
       man5:
         svcname: isns
   client:
+    enabled: False  #see https://github.com/saltstack-formulas/iscsi-formula/issues/10
     pkgs:
       wanted:
         - open-iscsi


### PR DESCRIPTION
PR to disable `open-iscsi` client daemon on Ubuntu. 