### PR TITLE
Updated for OpenSUSE 15.0

### DIFF
--- a/iscsi/initiator/install.sls
+++ b/iscsi/initiator/install.sls
@@ -20,7 +20,9 @@ iscsi_initiator_unwanted_pkgs_{{ pkg }}:
 iscsi_initiator_wanted_pkgs_{{ pkg }}:
   pkg.installed:
     - name: {{ pkg }}
+        {%- if iscsi.client.pkghold %}
     - hold: {{ iscsi.client.pkghold }}
+        {%- endif %}
     - reload: True
     - require_in:
       - file: iscsi_initiator_service_config

--- a/iscsi/isns/install.sls
+++ b/iscsi/isns/install.sls
@@ -20,7 +20,9 @@ iscsi_isnsd_remove_{{ pkg }}_pkg:
 iscsi_isnsd_install_{{ pkg }}_pkg:
   pkg.installed:
     - name: {{ pkg }}
+        {%- if iscsi.isns.pkghold %}
     - hold: {{ iscsi.isns.pkghold }}
+        {%- endif %}
     - reload: True
     - require_in:
       - file: iscsi_isnsd_service_config

--- a/iscsi/osfamilymap.yaml
+++ b/iscsi/osfamilymap.yaml
@@ -135,8 +135,14 @@ Suse:
   server:
     pkgs:
       wanted:
-        - yast2-iscsi-lio-server
-        - iscsiuio
+        - python3-configshell-fb
+        - python3-pyudev
+        - python3-rtslib-fb
+        - python3-targetcli-fb
+        - python3-urwid
+        - targetcli-fb-common
         - libiscsi-utils
+        - iscsiuio
+        - yast2-iscsi-lio-server
         - qemu-block-iscsi
 

--- a/iscsi/osfamilymap.yaml
+++ b/iscsi/osfamilymap.yaml
@@ -125,8 +125,12 @@ Suse:
   client:
     pkgs:
       wanted:
+        - libopeniscsiusr0_2_0
         - open-iscsi
+        - libiscsi8
+        - librdmacm1
         - qemu-block-iscsi
+        - iscsiuio
         - yast2-iscsi-client
   server:
     pkgs:

--- a/iscsi/target/install.sls
+++ b/iscsi/target/install.sls
@@ -20,7 +20,9 @@ iscsi_target_unwanted_pkgs_{{ pkg }}:
 iscsi_target_wanted_pkgs_{{ pkg }}:
   pkg.installed:
     - name: {{ pkg }}
+        {%- if iscsi.server.pkghold %}
     - hold: {{ iscsi.server.pkghold }}
+        {%- endif %}
     - reload: True
     - require_in:
       - file: iscsi_target_service_config


### PR DESCRIPTION
This PR adds packages which are needed on OpenSUSE for `open-scsi`.

```
              installed:
                  ----------
                  libopeniscsiusr0_2_0:
                      ----------
                      new:
                          2.0.876-lp150.9.6.1
                      old:
                  open-iscsi:
                      ----------
                      new:
                          2.0.876-lp150.9.6.1
                      old:
                installed:
                  ----------
                  libiscsi8:
                      ----------
                      new:
                          1.18.0-lp150.1.10
                      old:
                  librdmacm1:
                      ----------
                      new:
                          16.4-lp150.3.2
                      old:
                  qemu-block-iscsi:
                      ----------
                      new:
                          2.11.2-lp150.7.15.1
                      old:

              ----------
              installed:
                  ----------
                  iscsiuio:
                      ----------
                      new:
                          0.7.8.2-lp150.9.6.1
                      old:
                  yast2-iscsi-client:
                      ----------
                      new:
                          4.0.0-lp150.1.1
                      old: