### PR TITLE
fix(os): archlinux fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ AUR iscsi packages are supported. Run `users` state (users-formula) to create re
 
         iscsi:
         {% if grains.os == 'Arch' %}
-          user: iscsimake
+          user: iscsimake  #already defined in initiator/defaults.yaml
 
         users:
           iscsimake:

--- a/iscsi/initiator/defaults.yaml
+++ b/iscsi/initiator/defaults.yaml
@@ -1,7 +1,7 @@
 # vim: sts=2 ts=2 sw= et ai
 #
 iscsi:
-  user: iscsiuser      #not used unless archlinux
+  user: iscsimake      #archlinux only
   initiator:
     iscsid:                           #FreeBSD Foundation
       man5:

--- a/iscsi/initiator/install.sls
+++ b/iscsi/initiator/install.sls
@@ -76,7 +76,7 @@ iscsi_initiator_service_config:
         data: {{ data|json }}
         component: 'initiator'
         provider: {{ provider }}
-        json: {{ data['man5']['format']['json'] }}
+        json: {{ data['man5']['format']['json']|json }}
 
   {%- if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
 iscsi_initiator_kernel_module:
@@ -122,7 +122,11 @@ iscsi_initiator_service:
     - watch:
       - file: iscsi_initiator_service_config
         {%- endif %}
+        {%- if data.man5.svcname is iterable and data.man5.svcname is not string %}
+    - names: {{ data.man5.svcname|json }}
+        {%- else %}
     - name: {{ data.man5.svcname }}
+        {%- endif %}
         {%- if data.man5.kmodule %}
     - unless: {{ iscsi.kernel.modquery }} {{ data.man5.kmodule }}
         {%- endif %}

--- a/iscsi/osfamilymap.yaml
+++ b/iscsi/osfamilymap.yaml
@@ -58,6 +58,12 @@ Gentoo:
         kmodule: iscsi_tcp
 
 Arch:
+  initiator:
+    open-iscsi:
+      man5:
+        svcname:   ##open-iscsi on archlinux uses non-standard service names
+         - iscsi
+         - iscsid
   user: iscsimake
   client:
     make:

--- a/iscsi/target/install.sls
+++ b/iscsi/target/install.sls
@@ -76,7 +76,7 @@ iscsi_target_service_config:
         data: {{ data|json }}
         component: 'target'
         provider: {{ provider }}
-        json: {{ data['man5']['format']['json'] }}
+        json: {{ data['man5']['format']['json']|json }}
 
   {%- if iscsi.kernel.mess_with_kernel and data.man5.kmodule and data.man5.kloadtext %}
 iscsi_target_kernel_module:

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,22 @@
 #Sample pillars for iSNS/iSCSI on FreeBSD and GNU/Linux
 
+  {% if grains.os == 'Arch' %}
+     ### this user is needed for archlinux
+users:
+  iscsimake:
+    sudouser: True
+    shell: /bin/bash
+    empty_password: True
+    home: /home/iscsimake
+    createhome: True
+    optional_groups:
+      - wheel
+      - root
+    sudo_rules:
+     - 'ALL=(ALL) ALL'
+  {% endif %}
+
+
 iscsi:
   isns:
     enabled: True


### PR DESCRIPTION
Verified on Arch.
```
          ID: iscsi_target_wanted_pkgs_python-pip
    Function: pkg.installed
        Name: python-pip
      Result: True
     Comment: All specified packages are already installed
     Started: 03:08:19.820510
    Duration: 34.528 ms
     Changes:   
----------
          ID: iscsi_target_wanted_pkgs_thin-provisioning-tools
    Function: pkg.installed
        Name: thin-provisioning-tools
      Result: True
     Comment: All specified packages are already installed
     Started: 03:08:19.855241
    Duration: 23.145 ms
     Changes:   
----------
          ID: iscsi_target_wanted_pkgs_linux-lts
    Function: pkg.installed
        Name: linux-lts
      Result: True
     Comment: All specified packages are already installed
     Started: 03:08:19.878509
    Duration: 22.445 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_python-rtslib-fb
    Function: file.directory
        Name: /home/iscsimake
      Result: True
     Comment: The directory /home/iscsimake is in the correct state
     Started: 03:08:19.908444
    Duration: 0.528 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_python-rtslib-fb
    Function: git.latest
        Name: https://aur.archlinux.org/python-rtslib-fb.git
      Result: True
     Comment: Repository /home/iscsimake/python-rtslib-fb is up-to-date
     Started: 03:08:19.916784
    Duration: 1166.904 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_python-rtslib-fb
    Function: cmd.run
        Name: makepkg -si --noconfirm -f
      Result: True
     Comment: Command "makepkg -si --noconfirm -f" run
     Started: 03:08:21.086187
    Duration: 2535.094 ms
     Changes:   
              ----------
              pid:
                  1218
              retcode:
                  0
              stderr:
                  ==> Making package: python-rtslib-fb 2.1.fb69-2 (Thu Sep 12 03:08:21 2019)
                  ==> Checking runtime dependencies...
                  ==> Checking buildtime dependencies...
                  ==> Retrieving sources...
                    -> Found v2.1.fb69.tar.gz
                    -> Found target.service
                  ==> Validating source files with sha512sums...
                      v2.1.fb69.tar.gz ... Passed
                      target.service ... Passed
                  ==> Extracting sources...
                    -> Extracting v2.1.fb69.tar.gz with bsdtar
                  ==> Starting prepare()...
                  ==> Removing existing $pkgdir/ directory...
                  ==> Entering fakeroot environment...
                  ==> Starting package_python-rtslib-fb()...
                  ==> Tidying install...
                    -> Removing libtool files...
                    -> Purging unwanted files...
                    -> Removing static library files...
                    -> Stripping unneeded symbols from binaries and libraries...
                    -> Compressing man and info pages...
                  ==> Checking for packaging issues...
                  ==> Creating package "python-rtslib-fb"...
                    -> Generating .PKGINFO file...
                    -> Generating .BUILDINFO file...
                    -> Generating .MTREE file...
                    -> Compressing package...
                  ==> Leaving fakeroot environment.
                  ==> Finished making: python-rtslib-fb 2.1.fb69-2 (Thu Sep 12 03:08:23 2019)
                  ==> Installing python-rtslib-fb package group with pacman -U...
                  warning: python-rtslib-fb-2.1.fb69-2 is up to date -- reinstalling
                  warning: directory permissions differ on /etc/target/
                  filesystem: 750  package: 755
              stdout:
                  running install
                  running build
                  running build_py
                  running build_scripts
                  running install_lib
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/alua.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/utils.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/__init__.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/root.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/target.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/fabric.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/node.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  copying build/lib/rtslib/tcm.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/alua.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/utils.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/__init__.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/root.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/target.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/fabric.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/node.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  copying build/lib/rtslib_fb/tcm.py -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/alua.py to alua.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/utils.py to utils.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/__init__.py to __init__.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/root.py to root.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/target.py to target.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/fabric.py to fabric.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/node.py to node.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib/tcm.py to tcm.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/alua.py to alua.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/utils.py to utils.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/__init__.py to __init__.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/root.py to root.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/target.py to target.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/fabric.py to fabric.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/node.py to node.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb/tcm.py to tcm.cpython-37.pyc
                  writing byte-compilation script '/tmp/tmp_3q6uqjl.py'
                  /usr/bin/python /tmp/tmp_3q6uqjl.py
                  removing /tmp/tmp_3q6uqjl.py
                  running install_egg_info
                  running egg_info
                  writing rtslib_fb.egg-info/PKG-INFO
                  writing dependency_links to rtslib_fb.egg-info/dependency_links.txt
                  writing requirements to rtslib_fb.egg-info/requires.txt
                  writing top-level names to rtslib_fb.egg-info/top_level.txt
                  reading manifest file 'rtslib_fb.egg-info/SOURCES.txt'
                  writing manifest file 'rtslib_fb.egg-info/SOURCES.txt'
                  Copying rtslib_fb.egg-info to /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/lib/python3.7/site-packages/rtslib_fb-2.1.69-py3.7.egg-info
                  running install_scripts
                  creating /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/bin
                  copying build/scripts-3.7/targetctl -> /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/bin
                  changing mode of /home/iscsimake/python-rtslib-fb/pkg/python-rtslib-fb/usr/bin/targetctl to 755
                  loading packages...
                  resolving dependencies...
                  looking for conflicting packages...
                  
                  Packages (1) python-rtslib-fb-2.1.fb69-2
                  
                  Total Installed Size:  1.01 MiB
                  Net Upgrade Size:      0.00 MiB
                  
                  :: Proceed with installation? [Y/n] 
                  checking keyring...
                  checking package integrity...
                  loading package files...
                  checking for file conflicts...
                  checking available disk space...
                  :: Processing package changes...
                  reinstalling python-rtslib-fb...
                  :: Running post-transaction hooks...
                  (1/2) Reloading system manager configuration...
                  (2/2) Arming ConditionNeedsUpdate...
----------
          ID: iscsi_target_make_pkg_python-configshell-fb
    Function: file.directory
        Name: /home/iscsimake
      Result: True
     Comment: The directory /home/iscsimake is in the correct state
     Started: 03:08:23.621519
    Duration: 0.686 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_python-configshell-fb
    Function: git.latest
        Name: https://aur.archlinux.org/python-configshell-fb.git
      Result: True
     Comment: Repository /home/iscsimake/python-configshell-fb is up-to-date
     Started: 03:08:23.622729
    Duration: 1144.49 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_python-configshell-fb
    Function: cmd.run
        Name: makepkg -si --noconfirm -f
      Result: True
     Comment: Command "makepkg -si --noconfirm -f" run
     Started: 03:08:24.767489
    Duration: 2706.517 ms
     Changes:   
              ----------
              pid:
                  2096
              retcode:
                  0
              stderr:
                  ==> Making package: python-configshell-fb 1.1.fb25-1 (Thu Sep 12 03:08:25 2019)
                  ==> Checking runtime dependencies...
                  ==> Checking buildtime dependencies...
                  ==> Retrieving sources...
                    -> Found v1.1.fb25.tar.gz
                  ==> Validating source files with sha512sums...
                      v1.1.fb25.tar.gz ... Passed
                  ==> Extracting sources...
                    -> Extracting v1.1.fb25.tar.gz with bsdtar
                  ==> Removing existing $pkgdir/ directory...
                  ==> Entering fakeroot environment...
                  ==> Starting package_python-configshell-fb()...
                  ==> Tidying install...
                    -> Removing libtool files...
                    -> Purging unwanted files...
                    -> Removing static library files...
                    -> Stripping unneeded symbols from binaries and libraries...
                    -> Compressing man and info pages...
                  ==> Checking for packaging issues...
                  ==> Creating package "python-configshell-fb"...
                    -> Generating .PKGINFO file...
                    -> Generating .BUILDINFO file...
                    -> Generating .MTREE file...
                    -> Compressing package...
                  ==> Starting package_python2-configshell-fb()...
                  ==> Tidying install...
                    -> Removing libtool files...
                    -> Purging unwanted files...
                    -> Removing static library files...
                    -> Stripping unneeded symbols from binaries and libraries...
                    -> Compressing man and info pages...
                  ==> Checking for packaging issues...
                  ==> Creating package "python2-configshell-fb"...
                    -> Generating .PKGINFO file...
                    -> Generating .BUILDINFO file...
                    -> Generating .MTREE file...
                    -> Compressing package...
                  ==> Leaving fakeroot environment.
                  ==> Finished making: python-configshell-fb 1.1.fb25-1 (Thu Sep 12 03:08:27 2019)
                  ==> Installing python-configshell-fb package group with pacman -U...
                  warning: python-configshell-fb-1.1.fb25-1 is up to date -- reinstalling
                  warning: python2-configshell-fb-1.1.fb25-1 is up to date -- reinstalling
              stdout:
                  running install
                  running build
                  running build_py
                  running install_lib
                  creating /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr
                  creating /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib
                  creating /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7
                  creating /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages
                  creating /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  copying build/lib/configshell/log.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  copying build/lib/configshell/console.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  copying build/lib/configshell/__init__.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  copying build/lib/configshell/prefs.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  copying build/lib/configshell/shell.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  copying build/lib/configshell/node.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell
                  creating /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/log.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/console.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/__init__.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/prefs.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/shell.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/node.py -> /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell/log.py to log.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell/console.py to console.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell/__init__.py to __init__.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell/prefs.py to prefs.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell/shell.py to shell.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell/node.py to node.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb/log.py to log.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb/console.py to console.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb/__init__.py to __init__.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb/prefs.py to prefs.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb/shell.py to shell.cpython-37.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb/node.py to node.cpython-37.pyc
                  writing byte-compilation script '/tmp/tmprc__g44e.py'
                  /usr/bin/python /tmp/tmprc__g44e.py
                  removing /tmp/tmprc__g44e.py
                  running install_egg_info
                  running egg_info
                  writing configshell_fb.egg-info/PKG-INFO
                  writing dependency_links to configshell_fb.egg-info/dependency_links.txt
                  writing requirements to configshell_fb.egg-info/requires.txt
                  writing top-level names to configshell_fb.egg-info/top_level.txt
                  reading manifest file 'configshell_fb.egg-info/SOURCES.txt'
                  writing manifest file 'configshell_fb.egg-info/SOURCES.txt'
                  Copying configshell_fb.egg-info to /home/iscsimake/python-configshell-fb/pkg/python-configshell-fb/usr/lib/python3.7/site-packages/configshell_fb-1.1.25-py3.7.egg-info
                  running install_scripts
                  running install
                  running build
                  running build_py
                  running install_lib
                  creating /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr
                  creating /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib
                  creating /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7
                  creating /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages
                  creating /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  copying build/lib/configshell/log.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  copying build/lib/configshell/console.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  copying build/lib/configshell/__init__.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  copying build/lib/configshell/prefs.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  copying build/lib/configshell/shell.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  copying build/lib/configshell/node.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell
                  creating /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/log.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/console.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/__init__.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/prefs.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/shell.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  copying build/lib/configshell_fb/node.py -> /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell/log.py to log.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell/console.py to console.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell/__init__.py to __init__.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell/prefs.py to prefs.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell/shell.py to shell.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell/node.py to node.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb/log.py to log.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb/console.py to console.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb/__init__.py to __init__.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb/prefs.py to prefs.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb/shell.py to shell.pyc
                  byte-compiling /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb/node.py to node.pyc
                  writing byte-compilation script '/tmp/tmpCAPC1z.py'
                  /usr/bin/python2 -O /tmp/tmpCAPC1z.py
                  removing /tmp/tmpCAPC1z.py
                  running install_egg_info
                  running egg_info
                  writing requirements to configshell_fb.egg-info/requires.txt
                  writing configshell_fb.egg-info/PKG-INFO
                  writing top-level names to configshell_fb.egg-info/top_level.txt
                  writing dependency_links to configshell_fb.egg-info/dependency_links.txt
                  reading manifest file 'configshell_fb.egg-info/SOURCES.txt'
                  writing manifest file 'configshell_fb.egg-info/SOURCES.txt'
                  Copying configshell_fb.egg-info to /home/iscsimake/python-configshell-fb/pkg/python2-configshell-fb/usr/lib/python2.7/site-packages/configshell_fb-1.1.25-py2.7.egg-info
                  running install_scripts
                  loading packages...
                  resolving dependencies...
                  looking for conflicting packages...
                  
                  Packages (2) python-configshell-fb-1.1.fb25-1  python2-configshell-fb-1.1.fb25-1
                  
                  Total Installed Size:  1.41 MiB
                  Net Upgrade Size:      0.00 MiB
                  
                  :: Proceed with installation? [Y/n] 
                  checking keyring...
                  checking package integrity...
                  loading package files...
                  checking for file conflicts...
                  checking available disk space...
                  :: Processing package changes...
                  reinstalling python-configshell-fb...
                  reinstalling python2-configshell-fb...
                  :: Running post-transaction hooks...
                  (1/1) Arming ConditionNeedsUpdate...
----------
          ID: iscsi_target_make_pkg_targetcli-fb
    Function: file.directory
        Name: /home/iscsimake
      Result: True
     Comment: The directory /home/iscsimake is in the correct state
     Started: 03:08:27.474244
    Duration: 0.633 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_targetcli-fb
    Function: git.latest
        Name: https://aur.archlinux.org/targetcli-fb.git
      Result: True
     Comment: Repository /home/iscsimake/targetcli-fb is up-to-date
     Started: 03:08:27.475354
    Duration: 1146.853 ms
     Changes:   
----------
          ID: iscsi_target_make_pkg_targetcli-fb
    Function: cmd.run
        Name: makepkg -si --noconfirm -f
      Result: True
     Comment: Command "makepkg -si --noconfirm -f" run
     Started: 03:08:28.622550
    Duration: 1587.901 ms
     Changes:   
              ----------
              pid:
                  3377
              retcode:
                  0
              stderr:
                  ==> Making package: targetcli-fb 2.1.fb49-1 (Thu Sep 12 03:08:28 2019)
                  ==> Checking runtime dependencies...
                  ==> Checking buildtime dependencies...
                  ==> Retrieving sources...
                    -> Found v2.1.fb49.tar.gz
                  ==> Validating source files with sha512sums...
                      v2.1.fb49.tar.gz ... Passed
                  ==> Extracting sources...
                    -> Extracting v2.1.fb49.tar.gz with bsdtar
                  ==> Removing existing $pkgdir/ directory...
                  ==> Starting build()...
                  /usr/lib/python3.7/site-packages/setuptools/dist.py:483: UserWarning: The version specified ('2.1.fb49') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
                    "details." % self.metadata.version
                  ==> Entering fakeroot environment...
                  ==> Starting package()...
                  /usr/lib/python3.7/site-packages/setuptools/dist.py:483: UserWarning: The version specified ('2.1.fb49') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
                    "details." % self.metadata.version
                  ==> Tidying install...
                    -> Removing libtool files...
                    -> Purging unwanted files...
                    -> Removing static library files...
                    -> Stripping unneeded symbols from binaries and libraries...
                    -> Compressing man and info pages...
                  ==> Checking for packaging issues...
                  ==> Creating package "targetcli-fb"...
                    -> Generating .PKGINFO file...
                    -> Generating .BUILDINFO file...
                    -> Generating .MTREE file...
                    -> Compressing package...
                  ==> Leaving fakeroot environment.
                  ==> Finished making: targetcli-fb 2.1.fb49-1 (Thu Sep 12 03:08:30 2019)
                  ==> Installing package targetcli-fb with pacman -U...
                  warning: targetcli-fb-2.1.fb49-1 is up to date -- reinstalling
              stdout:
                  running build
                  running build_py
                  running build_scripts
                  running install
                  running install_lib
                  creating /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr
                  creating /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib
                  creating /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7
                  creating /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages
                  creating /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  copying build/lib/targetcli/ui_root.py -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  copying build/lib/targetcli/ui_node.py -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  copying build/lib/targetcli/__init__.py -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  copying build/lib/targetcli/version.py -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  copying build/lib/targetcli/ui_backstore.py -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  copying build/lib/targetcli/ui_target.py -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli
                  byte-compiling /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli/ui_root.py to ui_root.cpython-37.pyc
                  byte-compiling /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli/ui_node.py to ui_node.cpython-37.pyc
                  byte-compiling /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli/__init__.py to __init__.cpython-37.pyc
                  byte-compiling /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli/version.py to version.cpython-37.pyc
                  byte-compiling /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli/ui_backstore.py to ui_backstore.cpython-37.pyc
                  byte-compiling /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli/ui_target.py to ui_target.cpython-37.pyc
                  writing byte-compilation script '/tmp/tmpka5nz9sp.py'
                  /usr/bin/python /tmp/tmpka5nz9sp.py
                  removing /tmp/tmpka5nz9sp.py
                  running install_egg_info
                  running egg_info
                  writing targetcli_fb.egg-info/PKG-INFO
                  writing dependency_links to targetcli_fb.egg-info/dependency_links.txt
                  writing top-level names to targetcli_fb.egg-info/top_level.txt
                  reading manifest file 'targetcli_fb.egg-info/SOURCES.txt'
                  writing manifest file 'targetcli_fb.egg-info/SOURCES.txt'
                  Copying targetcli_fb.egg-info to /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/lib/python3.7/site-packages/targetcli_fb-2.1.fb49-py3.7.egg-info
                  running install_scripts
                  creating /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/bin
                  copying build/scripts-3.7/targetcli -> /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/bin
                  changing mode of /home/iscsimake/targetcli-fb/pkg/targetcli-fb/usr/bin/targetcli to 755
                  loading packages...
                  resolving dependencies...
                  looking for conflicting packages...
                  
                  Packages (1) targetcli-fb-2.1.fb49-1
                  
                  Total Installed Size:  0.34 MiB
                  Net Upgrade Size:      0.00 MiB
                  
                  :: Proceed with installation? [Y/n] 
                  checking keyring...
                  checking package integrity...
                  loading package files...
                  checking for file conflicts...
                  checking available disk space...
                  :: Processing package changes...
                  reinstalling targetcli-fb...
                  :: Running post-transaction hooks...
                  (1/1) Arming ConditionNeedsUpdate...
----------
          ID: iscsi_target_service_config
    Function: file.managed
        Name: /etc/target/saveconfig.json
      Result: True
     Comment: File /etc/target/saveconfig.json is in the correct state
     Started: 03:08:30.211666
    Duration: 47.383 ms
     Changes:   
----------
          ID: iscsi_target_service_running
    Function: service.running
        Name: target
      Result: True
     Comment: unless condition is true
     Started: 03:08:30.261371
    Duration: 647.283 ms
     Changes:   
----------
          ID: iscsi_initiator_wanted_pkgs_open-iscsi
    Function: pkg.installed
        Name: open-iscsi
      Result: True
     Comment: All specified packages are already installed
     Started: 03:08:30.908906
    Duration: 23.897 ms
     Changes:   
----------
          ID: iscsi_initiator_service_config
    Function: file.managed
        Name: /etc/iscsi/iscsid.conf
      Result: True
     Comment: File /etc/iscsi/iscsid.conf is in the correct state
     Started: 03:08:30.933322
    Duration: 31.641 ms
     Changes:   
----------
          ID: iscsi_initiator_service
    Function: file.line
        Name: None
      Result: True
     Comment: onlyif condition is false
     Started: 03:08:30.965091
    Duration: 11.983 ms
     Changes:   
----------
          ID: iscsi_initiator_service
    Function: service.running
        Name: iscsi
      Result: True
     Comment: The service iscsi is already running
     Started: 03:08:30.977857
    Duration: 50.582 ms
     Changes:   
----------
          ID: iscsi_initiator_service
    Function: service.running
        Name: iscsid
      Result: True
     Comment: The service iscsid is already running
     Started: 03:08:31.029001
    Duration: 53.776 ms
     Changes:   
----------
          ID: iscsi_isnsd_install_open-isns_pkg
    Function: pkg.installed
        Name: open-isns
      Result: True
     Comment: All specified packages are already installed
     Started: 03:08:31.083068
    Duration: 25.367 ms
     Changes:   
----------
          ID: iscsi_isnsd_service_config
    Function: file.managed
        Name: /etc/isns/isnsd.conf
      Result: True
     Comment: File /etc/isns/isnsd.conf is in the correct state
     Started: 03:08:31.109008
    Duration: 120.709 ms
     Changes:   
----------
          ID: iscsi_isnsd_service
    Function: service.running
        Name: isnsd
      Result: True
     Comment: The service isnsd is already running
     Started: 03:08:31.806098
    Duration: 36.225 ms
     Changes:   

Summary for local
-------------
Succeeded: 22 (changed=3)
Failed:     0
-------------
Total states run:     22
Total run time:   11.419 s
```