### PR TITLE
fix(config): fix jinja; only create conf files if pillar data

### DIFF
--- a/iscsi/init.sls
+++ b/iscsi/init.sls
@@ -2,7 +2,7 @@
 # vim: ft=sls
 
 include:
-         {%- if grains.os_family in ('SArch',) %}
+         {%- if grains.os_family in ('Arch',) %}
              {# This sequence avoids /etc/isns/isnsd.conf conflict on Arch #}
   - iscsi.initiator
   - iscsi.target

--- a/iscsi/initiator/config/clean.sls
+++ b/iscsi/initiator/config/clean.sls
@@ -6,6 +6,8 @@
 {%- set sls_package_clean = tplroot ~ '.initiator.package.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
+    {%- if iscsi.config.data[iscsi.initiator.provider|string] %}
+
 include:
   - {{ sls_package_clean }}
 
@@ -14,3 +16,5 @@ iscsi-initiator-config-clean-file-absent:
     - name: {{ iscsi.config.name[iscsi.initiator.provider|string] }}
     - watch_in:
         - sls: {{ sls_package_clean }}
+
+    {%- endif %}

--- a/iscsi/initiator/config/files/default/iscsi.tmpl
+++ b/iscsi/initiator/config/files/default/iscsi.tmpl
@@ -16,6 +16,7 @@
 {%- if value is mapping %}
 {{shift}}{{ key }} {  # nickname
 {{ readconf(value, spaces|int+4) }}
+}
 {%- elif value is string or value is number %}
 {{shift}}{{ key }} = {{"'" if value is not string else ''}}{{ value }}{{"'" if value is not string else ''}}
 {% endif %}

--- a/iscsi/initiator/config/files/default/iscsi.tmpl
+++ b/iscsi/initiator/config/files/default/iscsi.tmpl
@@ -18,7 +18,7 @@
 {{ readconf(value, spaces|int+4) }}
 {%- elif value is string or value is number %}
 {{shift}}{{ key }} = {{"'" if value is not string else ''}}{{ value }}{{"'" if value is not string else ''}}
-{%- endif %}
+{% endif %}
 {%- endmacro -%}
 
 {{ readconf(data,  0) }}

--- a/iscsi/initiator/config/files/default/open-iscsi.tmpl
+++ b/iscsi/initiator/config/files/default/open-iscsi.tmpl
@@ -13,8 +13,8 @@
 
 {%- macro openiscsi(key, value, spaces=0) -%}
   {%- set shift = spaces * ' ' -%}
-{{shift}}{{ key }} = {{"'" if value is not string else ''}}{{ value }}{{"'" if value is not string else ''}}
-{%- endmacro -%}
+{{shift}}{{ key }} = {{ value ~ '\n' if value is string else '"' ~ value ~ '"\n' }}
+{%- endmacro %}
 
 {{ readconf(data,  0) }}
 

--- a/iscsi/initiator/config/install.sls
+++ b/iscsi/initiator/config/install.sls
@@ -4,15 +4,18 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_service_install = tplroot ~ '.initiator.service.install' %}
+{%- set sls_package_install = tplroot ~ '.initiator.package.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
 
+    {%- if iscsi.config.data[iscsi.initiator.provider|string] %}
+
 include:
   - {{ sls_service_install }}
+  - {{ sls_package_install }}
 
 iscsi-initiator-config-install-file-managed:
   file.managed:
-    - onlyif: {{ iscsi.config.data[iscsi.initiator.provider|string]|json }}
     - name: {{ iscsi.config.name[iscsi.initiator.provider] }}
     - source: {{ files_switch([iscsi.initiator.provider ~ '.tmpl'],
                               lookup='iscsi-initiator-config-install-file-managed',
@@ -26,6 +29,10 @@ iscsi-initiator-config-install-file-managed:
     - template: jinja
     - require_in:
       - sls: {{ sls_service_install }}
+    - require:
+      - sls: {{ sls_package_install }}
     - context:
       data: {{ iscsi.config.data[iscsi.initiator.provider|string]|json }}
       component: initiator
+
+    {%- endif %}

--- a/iscsi/initiator/make/clean.sls
+++ b/iscsi/initiator/make/clean.sls
@@ -4,11 +4,14 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_service_clean = tplroot ~ '.initiator.service.clean' %}
+{%- set sls_config_clean = tplroot ~ '.initiator.config.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
   {%- if iscsi.initiator.make.wanted %}
 include:
   - {{ sls_service_clean }}
+  - {{ sls_config_clean }}
+
       {%- for pkg in iscsi.initiator.make.wanted %}
 
 iscsi-initiator-package-make-clean-{{ pkg }}-removed:
@@ -16,6 +19,8 @@ iscsi-initiator-package-make-clean-{{ pkg }}-removed:
     - name: {{ pkg }}
     - require:
       - sls: {{ sls_service_clean }}
+      - sls: {{ sls_config_clean }}
 
       {%- endfor %}
+
   {%- endif %}

--- a/iscsi/initiator/make/install.sls
+++ b/iscsi/initiator/make/install.sls
@@ -4,12 +4,14 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_service_install = tplroot ~ '.initiator.service.install' %}
+{%- set sls_config_install = tplroot ~ '.initiator.config.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
   {%- if iscsi.initiator.make.wanted %}
       {%- if salt['cmd.run']("id iscsi.user", output_loglevel='quiet') %}
 include:
   - {{ sls_service_install }}
+  - {{ sls_config_install }}
 
 iscsi-initiator-make-file-directory:
   file.directory:
@@ -51,6 +53,7 @@ iscsi-initiator-make-{{ pkg }}-cmd-run:
       - git: iscsi-initiator-make-{{ pkg }}-git-latest
     - require_in:
       - sls: {{ sls_service_install }}
+      - sls: {{ sls_config_install }}
 
           {% endfor %}
       {%- endif %}

--- a/iscsi/initiator/package/install.sls
+++ b/iscsi/initiator/package/install.sls
@@ -4,10 +4,12 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_install = tplroot ~ '.initiator.config.install' %}
+{%- set sls_service_install = tplroot ~ '.initiator.service.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
   - {{ sls_config_install }}
+  - {{ sls_service_install }}
 
     {%- if iscsi.initiator.pkgs.unwanted %}
         {%- for pkg in iscsi.initiator.pkgs.unwanted %}
@@ -17,6 +19,7 @@ iscsi-initiator-package-install-{{ pkg }}-removed:
     - name: {{ pkg }}
     - require_in:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_service_install }}
 
         {%- endfor %}
     {%- endif %}
@@ -32,6 +35,7 @@ iscsi-initiator-package-install-{{ pkg }}-installed:
     - reload: True
     - require_in:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_service_install }}
 
         {%- endfor %}
     {%- endif %}

--- a/iscsi/initiator/service/clean.sls
+++ b/iscsi/initiator/service/clean.sls
@@ -13,8 +13,10 @@ iscsi-initiator-service-clean-service-dead:
   service.dead:
     - name: {{ iscsi.config.servicename[iscsi.initiator.provider] }}
     - enable: False
-    - require_in:
+        {%- if iscsi.config.data[iscsi.initiator.provider|string] %}
+    - watch_in:
       - sls: {{ sls_config_clean }}
+        {%- endif %}
 
     {%- if grains.os_family == 'FreeBSD' %}
 
@@ -25,5 +27,9 @@ iscsi-initiator-service-clean-file-line-freebsd:
     - mode: delete
     - backup: True
     - quiet: True
+        {%- if iscsi.config.data[iscsi.initiator.provider|string] %}
+    - watch_in:
+      - sls: {{ sls_config_clean }}
+        {%- endif %}
 
     {%- endif %}

--- a/iscsi/initiator/service/install.sls
+++ b/iscsi/initiator/service/install.sls
@@ -37,16 +37,18 @@ iscsi-initiator-service-install-service-running:
     - enable: True
     - onfail_in:
       - test: iscsi-initiator-service-install-check-status
+            {%- if iscsi.config.data[iscsi.initiator.provider|string] %}
+    - require:
+      - sls: {{ sls_config_install }}
     - watch:
       - file: iscsi-initiator-config-install-file-managed
+            {%- endif %}
         {%- endif %}
         {%- if servicename is iterable and servicename is not string %}
     - names: {{ servicename|json }}
           {%- else %}
     - name: {{ servicename }}
         {%- endif %}
-    - require:
-      - sls: {{ sls_config_install }}
 
 iscsi-initiator-service-install-check-status:
   test.show_notification:

--- a/iscsi/initiator/service/install.sls
+++ b/iscsi/initiator/service/install.sls
@@ -36,7 +36,7 @@ iscsi-initiator-service-install-service-running:
     - name: {{ servicename }}
     - enable: True
     - onfail_in:
-      - test: iscsi-initiator-service-install-failure-explanation
+      - test: iscsi-initiator-service-install-check-status
     - watch:
       - file: iscsi-initiator-config-install-file-managed
         {%- endif %}
@@ -48,7 +48,7 @@ iscsi-initiator-service-install-service-running:
     - require:
       - sls: {{ sls_config_install }}
 
-iscsi-initiator-service-install-failure-explanation:
+iscsi-initiator-service-install-check-status:
   test.show_notification:
     - text: |
         In certain circumstances the iscsi initiator service will not start.

--- a/iscsi/isns/config/clean.sls
+++ b/iscsi/isns/config/clean.sls
@@ -9,21 +9,30 @@
 include:
   - {{ sls_package_clean }}
 
+    {%- if iscsi.config.data[iscsi.isns.provider|string] %}
+
 iscsi-isns-config-clean-file-absent:
   file.absent:
     - name: {{ iscsi.config.name[iscsi.isns.provider] }}
     - watch_in:
         - sls: {{ sls_package_clean }}
 
-    {%- if 'isnsadm' in iscsi.config.name and iscsi.config.name['isnsadm'] %}
+    {%- endif %}
+    {%- if 'isnsadm' in iscsi.config.data and iscsi.config.data['isnsadm'] %}
+
 iscsi-isns-config-clean-file-absent-isnsadm:
   file.absent:
     - name: {{ iscsi.config.name['isnsadm'] }}
-    {%- endif %}
+    - watch_in:
+        - sls: {{ sls_package_clean }}
 
-    {%- if 'isnsdd' in iscsi.config.name and iscsi.config.name['isnsdd'] %}
+    {%- endif %}
+    {%- if 'isnsdd' in iscsi.config.data and iscsi.config.data['isnsdd'] %}
+
 iscsi-isns-config-clean-file-absent-isnsdd:
   file.absent:
     - name: {{ iscsi.config.name['isnsdd'] }}
-    {%- endif %}
+    - watch_in:
+        - sls: {{ sls_package_clean }}
 
+    {%- endif %}

--- a/iscsi/isns/config/install.sls
+++ b/iscsi/isns/config/install.sls
@@ -9,10 +9,10 @@
 
 include:
   - {{ sls_service_install }}
+    {%- if iscsi.config.data[iscsi.isns.provider|string] %}
 
 iscsi-isns-config-install-file-managed-isnsd:
   file.managed:
-    - onlyif: {{ iscsi.config.data[iscsi.isns.provider|string]|json }}
     - name: {{ iscsi.config.name['isns'] }}
     - source: {{ files_switch([iscsi.isns.provider ~ '.tmpl'],
                               lookup='iscsi-isns-config-install-file-managed',
@@ -32,7 +32,9 @@ iscsi-isns-config-install-file-managed-isnsd:
       data: {{ iscsi.config.data[iscsi.isns.provider|string]|json }}
       component: isns
 
-    {%- if 'isnsadm' in iscsi.config.name and iscsi.config.name['isnsadm'] %}
+    {%- endif %}
+    {%- if 'isnsadm' in iscsi.config.data and iscsi.config.data['isnsadm'] %}
+
 iscsi-isns-config-install-file-managed-isnsadm:
   file.managed:
     - name: {{ iscsi.config.name['isnsadm'] }}
@@ -53,9 +55,10 @@ iscsi-isns-config-install-file-managed-isnsadm:
     - context:
       data: {{ iscsi.config.data[iscsi.isns.provider|string]|json }}
       component: isns
-    {%- endif %}
 
-    {%- if 'isnsdd' in iscsi.config.name and iscsi.config.name['isnsdd'] %}
+    {%- endif %}
+    {%- if 'isnsdd' in iscsi.config.data and iscsi.config.data['isnsdd'] %}
+
 iscsi-isns-config-install-file-managed-isnsdd:
   file.managed:
     - onlyif: {{ iscsi.config.name['isnsdd'] }}
@@ -77,4 +80,5 @@ iscsi-isns-config-install-file-managed-isnsdd:
     - context:
       data: {{ iscsi.config.data[iscsi.isns.provider|string]|json }}
       component: isns
+
     {%- endif %}

--- a/iscsi/isns/make/clean.sls
+++ b/iscsi/isns/make/clean.sls
@@ -4,11 +4,14 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_service_clean = tplroot ~ '.isns.service.clean' %}
+{%- set sls_config_clean = tplroot ~ '.isns.config.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
   {%- if iscsi.isns.make.wanted %}
 include:
   - {{ sls_service_clean }}
+  - {{ sls_config_clean }}
+
       {%- for pkg in iscsi.isns.make.wanted %}
 
 iscsi-isns-package-make-clean-{{ pkg }}-removed:
@@ -16,6 +19,8 @@ iscsi-isns-package-make-clean-{{ pkg }}-removed:
     - name: {{ pkg }}
     - require:
       - sls: {{ sls_service_clean }}
+      - sls: {{ sls_config_clean }}
 
       {%- endfor %}
+
   {%- endif %}

--- a/iscsi/isns/make/install.sls
+++ b/iscsi/isns/make/install.sls
@@ -4,12 +4,14 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_service_install = tplroot ~ '.isns.service.install' %}
+{%- set sls_config_install = tplroot ~ '.isns.config.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
   {%- if iscsi.isns.make.wanted %}
       {%- if salt['cmd.run']("id iscsi.user", output_loglevel='quiet') %}
 include:
   - {{ sls_service_install }}
+  - {{ sls_config_install }}
 
 iscsi-isns-make-file-directory:
   file.directory:
@@ -49,6 +51,7 @@ iscsi-isns-make-{{ pkg }}-cmd-run:
       - git: iscsi-isns-make-{{ pkg }}-git-latest
     - require_in:
       - sls: {{ sls_service_install }}
+      - sls: {{ sls_config_install }}
 
           {% endfor %}
       {%- endif %}

--- a/iscsi/isns/package/clean.sls
+++ b/iscsi/isns/package/clean.sls
@@ -3,22 +3,19 @@
 
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
-{%- set sls_config_clean = tplroot ~ '.isns.config.clean' %}
 {%- set sls_service_clean = tplroot ~ '.isns.service.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
-  - {{ sls_config_clean }}
   - {{ sls_service_clean }}
 
-    {%- for pkg in [iscsi.isns.pkgs.wanted, iscsi.isns.pkgs.unwanted] %}
+    {%- for pkg in iscsi.isns.pkgs.wanted %}
         {%- if pkg %}
 
 iscsi-isns-package-clean-{{ pkg }}-removed:
   pkg.purged:
     - name: {{ pkg }}
     - require:
-      - sls: {{ sls_config_clean }}
       - sls: {{ sls_service_clean }}
 
         {%- endif %}

--- a/iscsi/isns/package/install.sls
+++ b/iscsi/isns/package/install.sls
@@ -4,10 +4,12 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_install = tplroot ~ '.isns.config.install' %}
+{%- set sls_service_install = tplroot ~ '.isns.service.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
   - {{ sls_config_install }}
+  - {{ sls_service_install }}
 
     {%- if iscsi.isns.pkgs.unwanted %}
         {%- for pkg in iscsi.isns.pkgs.unwanted %}
@@ -17,6 +19,7 @@ iscsi-isns-package-install-{{ pkg }}-removed:
     - name: {{ pkg }}
     - require_in:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_service_install }}
 
         {%- endfor %}
     {%- endif %}
@@ -32,6 +35,7 @@ iscsi-isns-package-install-{{ pkg }}-installed:
     - reload: True
     - require_in:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_service_install }}
 
         {%- endfor %}
     {%- endif %}

--- a/iscsi/isns/service/clean.sls
+++ b/iscsi/isns/service/clean.sls
@@ -4,14 +4,19 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_clean = tplroot ~ '.isns.config.clean' %}
+{%- set sls_package_clean = tplroot ~ '.isns.package.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
   - {{ sls_config_clean }}
+  - {{ sls_package_clean }}
 
 iscsi-isns-service-clean-service-dead:
   service.dead:
     - name: {{ iscsi.config.servicename[iscsi.isns.provider] }}
     - enable: False
-    - require_in:
+        {%- if iscsi.config.data[iscsi.isns.provider|string] %}
+    - watch_in:
       - sls: {{ sls_config_clean }}
+      - sls: {{ sls_package_clean }}
+        {%- endif %}

--- a/iscsi/isns/service/install.sls
+++ b/iscsi/isns/service/install.sls
@@ -22,10 +22,10 @@ iscsi-isns-service-install-service-running:
     - enable: True
     - onfail_in:
       - test: iscsi-isns-service-install-check-status
-    - require:
-      - sls: {{ sls_config_install }}
+            {%- if iscsi.config.data[iscsi.isns.provider|string] %}
     - watch:
       - file: iscsi-isns-config-install-file-managed-isnsd
+            {%- endif %}
         {%- endif %}
         {%- if servicename is iterable and servicename is not string %}
     - names: {{ servicename|json }}

--- a/iscsi/isns/service/install.sls
+++ b/iscsi/isns/service/install.sls
@@ -21,7 +21,7 @@ iscsi-isns-service-install-service-running:
     - name: {{ servicename }}
     - enable: True
     - onfail_in:
-      - test: iscsi-isns-service-install-failure-explanation
+      - test: iscsi-isns-service-install-check-status
     - require:
       - sls: {{ sls_config_install }}
     - watch:
@@ -38,7 +38,7 @@ iscsi-isns-service-install-service-running:
             {%- endif %}
         {%- endif %}
 
-iscsi-isns-service-install-failure-explanation:
+iscsi-isns-service-install-check-status:
   test.show_notification:
     - text: |
         In certain circumstances the iscsi isns service will not start.

--- a/iscsi/target/config/clean.sls
+++ b/iscsi/target/config/clean.sls
@@ -6,6 +6,8 @@
 {%- set sls_package_clean = tplroot ~ '.target.package.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
+    {%- if iscsi.config.data[iscsi.target.provider|string] %}
+
 include:
   - {{ sls_package_clean }}
 
@@ -15,3 +17,5 @@ iscsi-target-config-clean-file-absent:
     - name: {{ iscsi.config.name[iscsi.target.provider|string] }}
     - watch_in:
         - sls: {{ sls_package_clean }}
+
+    {%- endif %}

--- a/iscsi/target/config/install.sls
+++ b/iscsi/target/config/install.sls
@@ -7,13 +7,13 @@
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
 
+    {%- if iscsi.config.data[iscsi.target.provider|string] %}
+
 include:
   - {{ sls_service_install }}
 
 iscsi-target-config-install-file-managed:
   file.managed:
-    - onlyif: {{ iscsi.config.data[iscsi.target.provider|string]|json }}
-    - unless: {{ grains.os in ('Amazon', 'MacOS') }}
     - name: {{ iscsi.config.name[iscsi.target.provider] }}
     - source: {{ files_switch([iscsi.target.provider ~ '.tmpl'],
                               lookup='iscsi-target-config-install-file-managed',
@@ -30,3 +30,5 @@ iscsi-target-config-install-file-managed:
     - context:
       data: {{ iscsi.config.data[iscsi.target.provider|string]|json }}
       component: target
+
+    {%- endif %}

--- a/iscsi/target/make/clean.sls
+++ b/iscsi/target/make/clean.sls
@@ -3,19 +3,16 @@
 
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
-{%- set sls_service_clean = tplroot ~ '.target.service.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
-  {%- if iscsi.target.make.wanted %}
-include:
-  - {{ sls_service_clean }}
+  {%- if iscsi.target.make.wanted and grains.os_family not in ('Arch',) %}
       {%- for pkg in iscsi.target.make.wanted %}
+          {%- if pkg %}
 
 iscsi-target-package-make-clean-{{ pkg }}-removed:
   pkg.removed:
     - name: {{ pkg }}
-    - require:
-      - sls: {{ sls_service_clean }}
 
+          {%- endif %}
       {%- endfor %}
   {%- endif %}

--- a/iscsi/target/make/install.sls
+++ b/iscsi/target/make/install.sls
@@ -4,12 +4,14 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_service_install = tplroot ~ '.target.service.install' %}
+{%- set sls_config_install = tplroot ~ '.target.config.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
   {%- if iscsi.target.make.wanted %}
       {%- if salt['cmd.run']("id iscsi.user", output_loglevel='quiet') %}
 include:
   - {{ sls_service_install }}
+  - {{ sls_config_install }}
 
 iscsi-target-make-file-directory:
   file.directory:
@@ -51,6 +53,7 @@ iscsi-target-make-{{ pkg }}-cmd-run:
       - git: iscsi-target-make-{{ pkg }}-git-latest
     - require_in:
       - sls: {{ sls_service_install }}
+      - sls: {{ sls_config_install }}
 
           {% endfor %}
       {%- endif %}

--- a/iscsi/target/package/install.sls
+++ b/iscsi/target/package/install.sls
@@ -4,10 +4,12 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_install = tplroot ~ '.target.config.install' %}
+{%- set sls_service_install = tplroot ~ '.target.service.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
   - {{ sls_config_install }}
+  - {{ sls_service_install }}
 
     {%- if iscsi.target.pkgs.unwanted %}
         {%- for pkg in iscsi.target.pkgs.unwanted %}
@@ -17,6 +19,7 @@ iscsi-target-package-install-{{ pkg }}-removed:
     - name: {{ pkg }}
     - require_in:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_service_install }}
 
         {%- endfor %}
     {%- endif %}
@@ -33,6 +36,7 @@ iscsi-target-package-install-{{ pkg }}-installed:
     - reload: True
     - require_in:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_service_install }}
 
         {%- endfor %}
     {%- endif %}

--- a/iscsi/target/service/clean.sls
+++ b/iscsi/target/service/clean.sls
@@ -4,18 +4,23 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_clean = tplroot ~ '.target.config.clean' %}
+{%- set sls_package_clean = tplroot ~ '.target.package.clean' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
   - {{ sls_config_clean }}
+  - {{ sls_package_clean }}
 
 iscsi-target-service-clean-service-dead:
   service.dead:
     - unless: {{ grains.os in ('Amazon', 'MacOS') }}
     - name: {{ iscsi.config.servicename[iscsi.target.provider] }}
     - enable: False
-    - require_in:
+      {%- if iscsi.config.data[iscsi.target.provider|string] %}
+    - watch_in:
       - sls: {{ sls_config_clean }}
+      - sls: {{ sls_package_clean }}
+      {%- endif %}
 
     {%- if grains.os_family == 'FreeBSD' %}
 
@@ -26,5 +31,8 @@ iscsi-target-service-clean-file-line-freebsd:
     - mode: delete
     - backup: True
     - quiet: True
+    - watch_in:
+      - sls: {{ sls_config_clean }}
+      - sls: {{ sls_package_clean }}
 
     {%- endif %}

--- a/iscsi/target/service/install.sls
+++ b/iscsi/target/service/install.sls
@@ -4,10 +4,12 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_install = tplroot ~ '.target.config.install' %}
+{%- set sls_package_install = tplroot ~ '.target.package.install' %}
 {%- from tplroot ~ "/map.jinja" import iscsi with context %}
 
 include:
   - {{ sls_config_install }}
+  - {{ sls_package_install }}
 
     {%- if grains.os_family == 'FreeBSD' %}
 iscsi-target-service-install-file-line-freebsd:
@@ -36,10 +38,13 @@ iscsi-target-service-install-service-running:
     - enable: True
     - onfail_in:
       - test: iscsi-target-service-install-check-status
+            {%- if iscsi.config.data[iscsi.target.provider|string] %}
     - require:
       - sls: {{ sls_config_install }}
+      - sls: {{ sls_package_install }}
     - watch:
       - file: iscsi-target-config-install-file-managed
+            {%- endif %}
         {%- endif %}
         {%- if servicename is iterable and servicename is not string %}
     - names: {{ servicename|json }}

--- a/iscsi/target/service/install.sls
+++ b/iscsi/target/service/install.sls
@@ -35,7 +35,7 @@ iscsi-target-service-install-service-running:
     - name: {{ servicename }}
     - enable: True
     - onfail_in:
-      - test: iscsi-target-service-install-failure-explanation
+      - test: iscsi-target-service-install-check-status
     - require:
       - sls: {{ sls_config_install }}
     - watch:
@@ -49,7 +49,7 @@ iscsi-target-service-install-service-running:
     - unless: {{ grains.os in ('Amazon', 'MacOS') }}
     - onlyif: {{ iscsi.target.enabled }}
 
-iscsi-target-service-install-failure-explanation:
+iscsi-target-service-install-check-status:
   test.show_notification:
     - text: |
         In certain circumstances the iscsi target service will not start.


### PR DESCRIPTION
This PR fixes a major bug.

**Bug**
- The `open-iscsi` configuration was being corrupted by `open-iscsi.tmpl` jinja.
```
                  +discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = '32768'node.conn[0].iscsi.MaxRecvDataSegmentLength = '262144'node.conn[0].iscsi.MaxXmitDataSegmentLength = '0'node.conn[0].timeo.login_timeout = '15'node.conn[0].timeo.logout_timeout = '15'node.conn[0].timeo.noop_out_interval = '5'node.conn[0].timeo.noop_out_timeout = '5'node.leading_login = Nonode.session.cmds_max = '128'node.session.err_timeo.abort_timeout = '15'node.session.err_timeo.lu_reset_timeout = '30'node.session.err_timeo.tgt_reset_timeout = '30'node.session.initial_login_retry_max = '8'node.session.iscsi.FastAbort = Yesnode.session.iscsi.FirstBurstLength = '262144'node.session.iscsi.ImmediateData = Yesnode.session.iscsi.InitialR2T = Nonode.session.iscsi.MaxBurstLength = '16776192'node.session.nr_sessions = '1'node.session.queue_depth = '32'node.session.scan = autonode.session.timeo.replacement_timeout = '120'node.session.xmit_thread_priority = '-20'node.startup = manual
```
- This PR fixes the jinja.
```
                  +discovery.sendtargets.iscsi.MaxRecvDataSegmentLength = "32768"
                  +node.conn[0].iscsi.MaxRecvDataSegmentLength = "262144"
                  +node.conn[0].iscsi.MaxXmitDataSegmentLength = "0"
                  +node.conn[0].timeo.login_timeout = "15"
                      .......
                  +node.session.xmit_thread_priority = "-20"
                   node.startup = manual
```

**Improvement**
If no "configuration" is defined in pillar data then do not create the configuration file.  The default configuration file provided by the package is good enough.